### PR TITLE
Config: support to read samlprovider from global

### DIFF
--- a/Config.py
+++ b/Config.py
@@ -124,7 +124,7 @@ class Config:
     def get_saml_info(self):
         idp_name = "default"
         while idp_name not in constants.valid_idp:
-            idp_name: str = input('What is the name of your provider? [' + ','.join(constants.valid_idp) + '] ').lower()
+            idp_name: str = input('What is the name of your provider? [' + ', '.join(constants.valid_idp) + '] ').lower()
         log_stream.info('Information may be obtained from your IdP admin')
         login_page: str = input('What is the application login URL for your IdP? ')
         login_title: str = input('What is the HTML title on the login page? ')
@@ -190,6 +190,8 @@ class Config:
         saved_password = None
         session_duration = None
         browser = None
+        saml_provider = None
+
         log_stream.info('Read settings from global block')
 
         try:
@@ -222,8 +224,14 @@ class Config:
             pass
         except configparser.NoSectionError:
             pass
+        try:
+            saml_provider = self.configSAML.get('global', 'samlProvider')
+        except configparser.NoOptionError:
+            pass
+        except configparser.NoSectionError:
+            pass
 
-        return aws_region, username, saved_password, session_duration, browser
+        return aws_region, username, saved_password, session_duration, saml_provider, browser
 
     def read_config(self, aws_profile_name, text_menu, use_idp, arg_username):
         account_number = None
@@ -234,35 +242,37 @@ class Config:
         aws_region = None
         browser = None
         username = None
+        saml_provider = None
         saved_password = None
         dsso_url = None
 
         # check for global variables. read if any, these will be overwritten by CLI and configuration in account blocks
-        aws_region, username, saved_password, session_duration, browser \
+        aws_region, username, saved_password, session_duration, saml_provider, browser \
             = self.read_global_settings()
 
         if text_menu is False and aws_profile_name is not None:
             try:
-                self.configSAML.get(aws_profile_name, 'samlProvider')
+                self.configSAML.has_option(aws_profile_name, 'samlProvider')
             except configparser.NoSectionError as e:
                 log_stream.fatal('No such AWS profile ' + aws_profile_name)
                 raise SystemExit(1)
 
             log_stream.info('Reading configuration info for profile ' + aws_profile_name)
+            profile = self.configSAML[aws_profile_name]
             try:
-                aws_region = self.configSAML[aws_profile_name]['awsRegion']
+                aws_region = getattr(profile, 'awsRegion', aws_region)
             except KeyError:
                 aws_region = None
             try:
-                session_duration = self.configSAML[aws_profile_name]['sessionDuration']
+                session_duration = profile['sessionDuration']
             except KeyError:
                 pass
             try:
-                account_number = self.configSAML[aws_profile_name]['accountNumber']
-                iam_role = self.configSAML[aws_profile_name]['IAMRole']
-                saml_provider = self.configSAML[aws_profile_name]['samlProvider']
-                username = self.configSAML[aws_profile_name]['username']
-                gui_name = self.configSAML[aws_profile_name]['guiName']
+                account_number = profile['accountNumber']
+                iam_role = profile['IAMRole']
+                saml_provider = getattr(profile, 'samlProvider', saml_provider)
+                username = getattr(profile, 'username', username)
+                gui_name = profile['guiName']
             except KeyError as missing_config_error:
                 missing_config_property: str = missing_config_error.args[0]
                 log_stream.fatal('Missing configuration property: ' + missing_config_property)

--- a/Utilities.py
+++ b/Utilities.py
@@ -211,7 +211,7 @@ def get_browser_type():
 
 
 def get_session_duration():
-    *nonsense, session_duration, browser = config.read_global_settings()
+    *nonsense, session_duration, saml_provider, browser = config.read_global_settings()
     if session_duration is None:
         session_duration = 0
     return session_duration


### PR DESCRIPTION
- Added `samlprovider` to global
- Fixed Utilities.py so return values are set correctly
- Changed the validation that the section exists in the config file.
- Replaced the direct access to attributes with `getattr`, so it can use the global defaults without errors.
